### PR TITLE
Better memoization of instances and layers.

### DIFF
--- a/lib/omc/layer.rb
+++ b/lib/omc/layer.rb
@@ -12,5 +12,11 @@ module Omc
       @stack = stack
       @attributes = attributes
     end
+
+    def instances
+      @instances ||= @stack.instances.select do |i|
+        i[:layer_ids].include? self[:layer_id]
+      end
+    end
   end
 end

--- a/lib/omc/stack.rb
+++ b/lib/omc/stack.rb
@@ -16,9 +16,8 @@ module Omc
       @attributes = attributes
     end
 
-    def instances layer_id: nil
-      options = layer_id.nil? ? {stack_id: self[:stack_id]} : {layer_id: layer_id}
-      @instances ||= client.describe_instances(options)[:instances].map do |instance|
+    def instances
+      @instances ||= client.describe_instances(stack_id: self[:stack_id])[:instances].map do |instance|
         ::Omc::Instance.new(self, instance)
       end
     end

--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -58,9 +58,14 @@ module Omc
       end
     end
 
+    def layer
+      if @layer_name
+        get_by_name(stack.layers, @layer_name, key: :shortname)
+      end
+    end
+
     def instance
-      layer_id = @layer_name ? stack.layers.detect{ |l| l[:shortname] == @layer_name }[:layer_id] : nil
-      instances = stack.instances(layer_id: layer_id)
+      instances = layer ? layer.instances : stack.instances
       instances.detect(&:online?) || abort("No running instances")
     end
 
@@ -76,10 +81,10 @@ module Omc
       @stack ||= get_by_name(account.stacks, @stack_name)
     end
 
-    def get_by_name collection, name
+    def get_by_name collection, name, key: :name
       collection.detect do |x|
-        x[:name] == name
-      end || abort("Can't find #{name.inspect} among #{collection.map{|x| x[:name] }.inspect}")
+        x[key] == name
+      end || abort("Can't find #{name.inspect} among #{collection.map{|x| x[key] }.inspect}")
     end
   end
 end


### PR DESCRIPTION
Old code would stash the instances based on the layer. Which meant the following was possible, even if the layers didn't share any instances in common:

``` ruby
stack = Omc::Stack.new
instances = stack.instances(layer_id: 'first-layer')

other_instances = stack.instances(layer_id: 'other-layer')

instances == other_instances
```
