### PR TITLE
Fallback to private_ip if instance has no public one

### DIFF
--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -39,7 +39,7 @@ module Omc
           i[:status],
           i[:availability_zone],
           i[:ec2_instance_id],
-          i[:public_ip],
+          i[:public_ip] || i[:private_ip],
         ]
       end
       thor.print_table(details)
@@ -70,7 +70,7 @@ module Omc
     end
 
     def ssh_host
-      "#{@user.name}@#{instance[:public_ip]}"
+      "#{@user.name}@#{instance[:public_ip] || instance[:private_ip]}"
     end
 
     def account

--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -39,7 +39,8 @@ module Omc
           i[:status],
           i[:availability_zone],
           i[:ec2_instance_id],
-          i[:public_ip] || i[:private_ip],
+          i[:public_ip],
+          i[:private_ip]
         ]
       end
       thor.print_table(details)


### PR DESCRIPTION
For instances in VPC, it's not necessary to assign public IPs to instance.