### PR TITLE
Fix console and db command by using shortname

### DIFF
--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -15,11 +15,11 @@ module Omc
     end
 
     def console
-      ssh_and_execute "cd /srv/www/#{app[:name]}/current && RAILS_ENV=#{app[:attributes]['RailsEnv']} bundle exec rails c"
+      ssh_and_execute "cd /srv/www/#{app[:shortname]}/current && RAILS_ENV=#{app[:attributes]['RailsEnv']} bundle exec rails c"
     end
 
     def db
-      ssh_and_execute "cd /srv/www/#{app[:name]}/current && RAILS_ENV=#{app[:attributes]['RailsEnv']} bundle exec rails db -p"
+      ssh_and_execute "cd /srv/www/#{app[:shortname]}/current && RAILS_ENV=#{app[:attributes]['RailsEnv']} bundle exec rails db -p"
     end
 
     def unicorn(action)


### PR DESCRIPTION
There're some cases that name != shortname. e.g. I have an app called `Blog` and its shortname turns out to be `blog`, which results in a directory not found error.
