### PR TITLE
Support commands through a bastion

### DIFF
--- a/lib/omc/cli.rb
+++ b/lib/omc/cli.rb
@@ -11,47 +11,50 @@ module Omc
 
     desc 'ssh STACK', 'Connect to an instance on a stack on an account'
     def ssh(stack)
-      command = StackCommand.new(user, stack, layer: options[:layer])
+      command = StackCommand.new(aws_account, user, stack, layer: options[:layer])
       command.ssh
     end
 
     desc 'ssh_exec STACK COMMAND', 'Connect to an instance on a stack on an account and execute a command'
     def ssh_exec(stack, user_command)
-      command = StackCommand.new(user, stack, layer: options[:layer])
+      command = StackCommand.new(aws_account, user, stack, layer: options[:layer])
       command.ssh_and_execute user_command
     end
 
     desc 'console STACK', 'Run a rails console on the given stack'
     method_option :app
     def console(stack)
-      command = StackCommand.new(user, stack, app: options[:app], layer: options[:layer])
+      command = StackCommand.new(aws_account, user, stack, app: options[:app], layer: options[:layer])
       command.console
     end
 
     desc 'db STACK', 'Connect and run the database client on the given stack'
     method_option :app
     def db(stack)
-      command = StackCommand.new(user, stack, app: options[:app], layer: options[:layer])
+      command = StackCommand.new(aws_account, user, stack, app: options[:app], layer: options[:layer])
       command.db
     end
 
     desc 'unicorn ACTION STACK', 'Connect and run the given action on the unicorns'
     method_option :app
     def unicorn(action, stack)
-      command = StackCommand.new(user, stack, app: options[:app])
+      command = StackCommand.new(aws_account, user, stack, app: options[:app])
       command.unicorn(action)
     end
 
     desc 'status STACK', 'Show the instance status for the given stack'
     def status(stack)
-      command = StackCommand.new(user, stack, app: options[:app], layer: options[:layer])
+      command = StackCommand.new(aws_account, user, stack, app: options[:app], layer: options[:layer])
       command.status(self)
     end
 
     private
     def user
-      iam_account = vault.account(account) || abort("Account #{account.inspect} not configured")
-      iam_account.users.first || abort("No users configured under #{account.inspect}")
+      aws_account.users.first || abort("No users configured under #{account.inspect}")
+    end
+
+    def aws_account
+      vault.account(account) || abort("Account #{account.inspect} not configured")
     end
 
     def account

--- a/omc.gemspec
+++ b/omc.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor", '~> 0.19'
-  spec.add_dependency "aws_cred_vault", '~> 0.0'
+  spec.add_dependency "aws_cred_vault", '~> 0.0.7'
   spec.add_dependency "aws-sdk", '~> 1.56'
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
This commit allows connection through a bastion (specified by a matching
bastion in the aws_cred_vault). It will execute all SSH commands
proxying through the given bastion, switching to the private IP of the
EC2 instance.