### PR TITLE
Add ability to RemoteForward

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ secret = "abcd1234"
 ```
 omc help
 ```
+
+Accepted ssh options:
+```
+-R 3000:localhost:3001 # Forwards port 3000 on the remote host to port 3001 on the localhost
+-A                     # Forward agent
+```
+
+Please the the ssh help for more detail.

--- a/lib/omc/cli.rb
+++ b/lib/omc/cli.rb
@@ -9,6 +9,7 @@ module Omc
     class_option :account, aliases: '-a'
     class_option :layer, aliases: '-l'
     class_option :forward_agent, aliases: "-A", type: :boolean, default: false
+    class_option :remote_forward, aliases: "-R", type: :string, default: nil
 
     desc 'ssh STACK', 'Connect to an instance on a stack on an account'
     def ssh(stack)
@@ -17,7 +18,8 @@ module Omc
         user,
         stack,
         layer: options[:layer],
-        forward_agent: options[:forward_agent]
+        forward_agent: options[:forward_agent],
+        remote_forward: options[:remote_forward]
       )
       command.ssh
     end

--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -3,13 +3,14 @@ require 'omc/account'
 
 module Omc
   class StackCommand
-    def initialize aws_account, user, stack_name, app: nil, layer: nil, forward_agent: false
+    def initialize aws_account, user, stack_name, app: nil, layer: nil, forward_agent: false, remote_forward: nil
       @aws_account = aws_account
       @user = user
       @stack_name = stack_name
       @app_name = app
       @layer_name = layer
       @forward_agent = forward_agent
+      @remote_forward = remote_forward
     end
 
     def ssh
@@ -100,8 +101,11 @@ module Omc
 
     def default_ssh_args
       [].tap do |args|
-        args.push("-o", "ProxyCommand ssh -W %h:%p #{bastion.host}") if bastion
+        proxy_command = "ProxyCommand ssh -W %h:%p #{bastion.host}"
+        proxy_command += " -R #{@remote_forward}" if @remote_forward
+        args.push("-o", proxy_command) if bastion
         args.push("-A") if @forward_agent
+        args.push("-R #{@remote_forward}") if @remote_forward
       end
     end
 

--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -101,9 +101,11 @@ module Omc
 
     def default_ssh_args
       [].tap do |args|
-        proxy_command = "ProxyCommand ssh -W %h:%p #{bastion.host}"
-        proxy_command += " -R #{@remote_forward}" if @remote_forward
-        args.push("-o", proxy_command) if bastion
+        if (bastion)
+          proxy_command = "ProxyCommand ssh -W %h:%p #{bastion.host}"
+          proxy_command += " -R #{@remote_forward}" if @remote_forward
+          args.push("-o", proxy_command)
+        end
         args.push("-A") if @forward_agent
         args.push("-R #{@remote_forward}") if @remote_forward
       end

--- a/lib/omc/version.rb
+++ b/lib/omc/version.rb
@@ -1,3 +1,3 @@
 module Omc
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end


### PR DESCRIPTION
This adds the ability to set a remote forward option in order to forward
ports to a remote server potentially through a bastion host.