### PR TITLE
Replace aws-sdk dependency

### DIFF
--- a/lib/omc/cli.rb
+++ b/lib/omc/cli.rb
@@ -1,6 +1,6 @@
 require 'thor'
 require 'aws_cred_vault'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require "omc/stack_command"
 require "omc/config"
 

--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'omc/account'
 
 module Omc

--- a/omc.gemspec
+++ b/omc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor", '~> 0.19'
   spec.add_dependency "aws_cred_vault", '~> 0.0.7'
-  spec.add_dependency "aws-sdk", '~> 1.56'
+  spec.add_dependency "aws-sdk-v1", '~> 1.56'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This change allows our end users to be able to require version 2 of
aws-sdk.

From AWS:

## Attention Library Authors

If you maintain a gem that has a dependency on version 1 of aws-sdk, I strongly recommend that you replace it with a dependency on aws-sdk-v1. This allows end users to require version 2 of aws-sdk.

[Read More](https://aws.amazon.com/blogs/developer/upcoming-stable-release-of-aws-sdk-for-ruby-version-2/)